### PR TITLE
Removes null from config, making it run with defaults

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -13,7 +13,7 @@ interface Config {
   main_comment: string;
 }
 
-export const getConfig = async (context: Context): Promise<Config | null> => {
+export const getConfig = async (context: Context): Promise<Config> => {
   const config: Config = await getConfigFromContext(
     context,
     "spellchecker.yml"
@@ -23,7 +23,7 @@ export const getConfig = async (context: Context): Promise<Config | null> => {
     const { owner, repo } = context.repo();
     context.log(`No spellchecker.yml found in repository '${owner}/${repo}'.`);
 
-    return null;
+    return defaultConfig;
   }
 
   if (!config.language) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,11 +18,6 @@ export = (app: Application) => {
 
     const config = await getConfig(context);
 
-    if (!config) {
-      context.log("Will not run spellchecker since no config was found.");
-      return;
-    }
-
     const headSha = context.payload.pull_request.head.sha;
     const baseSha = context.payload.pull_request.base.sha;
 


### PR DESCRIPTION
Hust a proposition from my side. Is there a reason why we don't just let it run with "sane" defaults?