### PR TITLE
Replace custom spellchecker with official one

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "probot": "^9.2.10",
     "probot-config": "^1.0.1",
     "remove-markdown": "^0.3.0",
-    "spellchecker": "https://github.com/cbrevik/node-spellchecker#21c3d15206d1ba967d16fae88d0c166a2671203c"
+    "spellchecker": "^3.7.0"
   },
   "devDependencies": {
     "@types/dotenv": "^6.1.1",

--- a/src/spellcheck.ts
+++ b/src/spellcheck.ts
@@ -1,3 +1,5 @@
+const { Spellchecker, ALWAYS_USE_HUNSPELL } = require("spellchecker");
+
 export interface Mispelled {
   text: string;
   start: number;
@@ -9,13 +11,14 @@ export default function initSpellchecker(
   dictionaryFolder: string,
   ignoredWords: string[]
 ) {
-  const SpellChecker = require("spellchecker");
+  const spellchecker = new Spellchecker();
+  spellchecker.setSpellcheckerType(ALWAYS_USE_HUNSPELL);
   const subfolder = sanitizeDictionaryFolder(dictionaryFolder, language);
-  SpellChecker.setDictionary(language, `dictionaries/${subfolder}`);
+  spellchecker.setDictionary(language, `dictionaries/${subfolder}`);
   ignoredWords = ignoredWords.map(t => t.toLowerCase());
 
   return function spellcheck(fullText: string): Array<Mispelled> {
-    const result = SpellChecker.checkSpelling(fullText);
+    const result = spellchecker.checkSpelling(fullText);
     const mispellings = [];
     for (let a = 0; a < result.length; a++) {
       const { start, end } = result[a];

--- a/yarn.lock
+++ b/yarn.lock
@@ -3333,6 +3333,11 @@ nan@^2.10.0, nan@^2.12.1:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.13.2.tgz#f51dc7ae66ba7d5d55e1e6d4d8092e802c9aefe7"
   integrity sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==
 
+nan@^2.14.0:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
+  integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -4493,12 +4498,13 @@ spdx-license-ids@^3.0.0:
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz#75ecd1a88de8c184ef015eafb51b5b48bfd11bb1"
   integrity sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA==
 
-"spellchecker@https://github.com/cbrevik/node-spellchecker#21c3d15206d1ba967d16fae88d0c166a2671203c":
-  version "3.5.2"
-  resolved "https://github.com/cbrevik/node-spellchecker#21c3d15206d1ba967d16fae88d0c166a2671203c"
+spellchecker@^3.7.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/spellchecker/-/spellchecker-3.7.0.tgz#d63e6fd612352b0108e7bbf942f271665ff63c8b"
+  integrity sha512-saQT4BR9nivbK70s0YjyIlSbZzO6bfWRULcGL2JU7fi7wotOnWl70P0QoUwwLywNQJQ47osgCo6GmOlqzRTxbQ==
   dependencies:
     any-promise "^1.3.0"
-    nan "^2.10.0"
+    nan "^2.14.0"
 
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"


### PR DESCRIPTION
Official one finally supports prefering Hunspell via API.
Also finally supports constructing new instances instead of a global default spellchecker.