### PR TITLE
feat: Add lines added threshold to config

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,12 @@
+{
+  "trailingComma": "all",
+  "singleQuote": true,
+  "printWidth": 80,
+  "semi": true,
+  "tabWidth": 2,
+  "bracketSpacing": true,
+  "jsxSingleQuote": false,
+  "useTabs": false,
+  "arrowParens": "always",
+  "proseWrap": "preserve"
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+  // See http://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+  // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+  // List of extensions which should be recommended for users of this workspace.
+  "recommendations": ["esbenp.prettier-vscode"],
+  // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+  "unwantedRecommendations": []
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
-import { Context } from "probot";
+import { Context } from 'probot';
 
-const getConfigFromContext = require("probot-config");
+const getConfigFromContext = require('probot-config');
 
 interface Config {
   // The language to spellcheck
@@ -11,12 +11,14 @@ interface Config {
   ignored_words: string[];
   // The main comment
   main_comment: string;
+  // Skipping spellcheck if added lines are fewer than the threshold
+  lines_changed_threshold: number;
 }
 
 export const getConfig = async (context: Context): Promise<Config> => {
   const config: Config = await getConfigFromContext(
     context,
-    "spellchecker.yml"
+    'spellchecker.yml',
   );
 
   if (!config) {
@@ -28,21 +30,20 @@ export const getConfig = async (context: Context): Promise<Config> => {
 
   if (!config.language) {
     context.log(
-      `Language was not set in spellchecker.yml, defaulting to ${
-        defaultConfig.language
-      }`
+      `Language was not set in spellchecker.yml, defaulting to ${defaultConfig.language}`,
     );
   }
 
   return {
     ...defaultConfig,
-    ...config
+    ...config,
   };
 };
 
 const defaultConfig: Config = {
-  language: "en_US",
-  dictionary_folder: "en",
-  main_comment: "I found one or more possible misspellings 😇",
-  ignored_words: []
+  language: 'en_US',
+  dictionary_folder: 'en',
+  main_comment: 'I found one or more possible misspellings 😇',
+  ignored_words: [],
+  lines_changed_threshold: -1,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,19 @@
-import { Application, Context } from "probot";
-import initSpellchecker from "./spellcheck";
-import { getDiff } from "./diff";
-import { extname } from "path";
-import { getConfig } from "./config";
-const removeMd = require("remove-markdown");
+import { Application, Context } from 'probot';
+import initSpellchecker from './spellcheck';
+import { getDiff } from './diff';
+import { extname } from 'path';
+import { getConfig } from './config';
+const removeMd = require('remove-markdown');
 
 export = (app: Application) => {
-  app.log("Yay, the app was loaded!");
+  app.log('Yay, the app was loaded!');
 
-  app.on(["pull_request.opened"], async (context: Context) => {
+  app.on(['pull_request.opened'], async (context: Context) => {
     const { owner, repo } = context.repo();
 
     const pull_request_number = context.payload.pull_request.number;
     context.log(
-      `Received webhook. Pull request #${pull_request_number} opened in repository '${owner}/${repo}'.`
+      `Received webhook. Pull request #${pull_request_number} opened in repository '${owner}/${repo}'.`,
     );
 
     const config = await getConfig(context);
@@ -26,20 +26,37 @@ export = (app: Application) => {
         base: baseSha,
         head: headSha,
         headers: {
-          accept: "application/vnd.github.v3.diff"
-        }
-      })
+          accept: 'application/vnd.github.v3.diff',
+        },
+      }),
     );
 
-    context.log("Getting file diffs");
+    context.log('Getting file diffs');
     const fileDiffs = getDiff(result.data);
 
-    context.log(`There were ${fileDiffs.length} files with added lines`);
+    const totalAddedLines = fileDiffs.reduce(
+      (acc, cur) => (acc += cur.addedLines.length),
+      0,
+    );
+
+    context.log(
+      `There were ${fileDiffs.length} files with a total of ${totalAddedLines} added lines`,
+    );
+
+    const addedLinesThreshold = config.lines_changed_threshold;
+
+    if (addedLinesThreshold > 0 && totalAddedLines <= addedLinesThreshold) {
+      context.log(
+        `The number of added lines are fewer than the configured threshold. Skipping spellcheck.`,
+      );
+
+      return;
+    }
 
     const spellcheck = initSpellchecker(
       config.language,
       config.dictionary_folder,
-      config.ignored_words
+      config.ignored_words,
     );
 
     const lineHits: Array<{
@@ -47,22 +64,25 @@ export = (app: Application) => {
       misspelled: string[];
       position: number;
     }> = [];
+
     for (let fileDiff of fileDiffs) {
       context.log(`Checking file ${fileDiff.path}`);
-      if (extname(fileDiff.path) === ".md") {
+
+      if (extname(fileDiff.path) === '.md') {
         for (let addedLine of fileDiff.addedLines) {
           const nonMdText = removeMd(addedLine.text);
-          const misspelled = spellcheck(nonMdText).map(m => m.text);
+          const misspelled = spellcheck(nonMdText).map((m) => m.text);
+
           if (misspelled.length) {
             lineHits.push({
               path: fileDiff.path,
               position: addedLine.diffLineNumber,
-              misspelled
+              misspelled,
             });
           }
         }
       } else {
-        context.log("Skipping spellcheck for non-.md file");
+        context.log('Skipping spellcheck for non-.md file');
       }
     }
 
@@ -72,19 +92,21 @@ export = (app: Application) => {
       const review: any = context.issue({
         commit_id: headSha,
         body: config.main_comment,
-        event: "COMMENT",
-        comments: lineHits.map(hit => ({
+        event: 'COMMENT',
+        comments: lineHits.map((hit) => ({
           body: `"${hit.misspelled.join('", "')}"`,
           path: hit.path,
-          position: hit.position
+          position: hit.position,
         })),
-        pull_number: pull_request_number
+        pull_number: pull_request_number,
       });
+
       delete review.number;
+
       try {
         await context.github.pulls.createReview(review);
       } catch (err) {
-        context.log("Creating review failed.");
+        context.log('Creating review failed.');
         context.log(err);
       }
     }


### PR DESCRIPTION
If the lines added are fewer than the set threshold, the spellchecker won't run.
I set the default threshold to -1 so the spellchecker will never skip if
the consumer haven't set a threshold in the config file.

Closes #18

